### PR TITLE
[Audio] Crashes on low-end device (multiple howler)

### DIFF
--- a/packages/utils-sound/src/createPlayLoop.svelte.ts
+++ b/packages/utils-sound/src/createPlayLoop.svelte.ts
@@ -6,6 +6,7 @@ export function createPlayLoop<TSoundName extends string>(options: {
 	howl: Howl;
 	newSound: (value: TSoundName) => GetSound<TSoundName>;
 	getSoundMap: () => GetSoundMap<TSoundName>;
+	initSoundVolume: (soundName: TSoundName) => void;
 }) {
 	type Sound = GetSound<TSoundName>;
 
@@ -16,6 +17,8 @@ export function createPlayLoop<TSoundName extends string>(options: {
 			soundId,
 			soundState: 'playing',
 		};
+
+		options.initSoundVolume(sound.soundName);
 	};
 
 	const soundPlayMap = {

--- a/packages/utils-sound/src/createPlayMusic.svelte.ts
+++ b/packages/utils-sound/src/createPlayMusic.svelte.ts
@@ -6,6 +6,7 @@ export function createPlayMusic<TSoundName extends string>(options: {
 	howl: Howl;
 	newSound: (value: TSoundName) => GetSound<TSoundName>;
 	getSoundMap: () => GetSoundMap<TSoundName>;
+	initSoundVolume: (soundName: TSoundName) => void;
 }) {
 	type Sound = GetSound<TSoundName>;
 
@@ -27,6 +28,7 @@ export function createPlayMusic<TSoundName extends string>(options: {
 			soundId,
 			soundState: 'playing',
 		};
+		options.initSoundVolume(sound.soundName);
 	};
 
 	const resumeMusic = (sound: Sound) => {

--- a/packages/utils-sound/src/createPlayOnce.svelte.ts
+++ b/packages/utils-sound/src/createPlayOnce.svelte.ts
@@ -6,6 +6,7 @@ export function createPlayOnce<TSoundName extends string>(options: {
 	howl: Howl;
 	newSound: (value: TSoundName) => GetSound<TSoundName>;
 	getSoundMap: () => GetSoundMap<TSoundName>;
+	initSoundVolume: (soundName: TSoundName) => void;
 }) {
 	type Sound = GetSound<TSoundName>;
 
@@ -16,6 +17,8 @@ export function createPlayOnce<TSoundName extends string>(options: {
 			soundId,
 			soundState: 'playing',
 		};
+
+		options.initSoundVolume(sound.soundName);
 
 		options.howl.on('end', (soundIdOnEnd) => {
 			if (soundIdOnEnd === soundId) {

--- a/packages/utils-sound/src/createSound.svelte.ts
+++ b/packages/utils-sound/src/createSound.svelte.ts
@@ -27,11 +27,16 @@ function createSound<TSoundName extends string>() {
 		// loadedAudio
 		loadedAudio = loadedAudioValue;
 
+		const howl = new Howl({
+			src: loadedAudio.src,
+			sprite: loadedAudio.sprite,
+			volume: 1,
+		});
 		// players
 		players = {
-			music: createPlayer<TSoundName, PlayMusic>({ loadedAudio, loop: true, createPlay: createPlayMusic<TSoundName> }), // prettier-ignore
-			loop: createPlayer<TSoundName, PlayLoop>({ loadedAudio, loop: true, createPlay: createPlayLoop<TSoundName> }), // prettier-ignore
-			once: createPlayer<TSoundName, PlayOnce>({ loadedAudio, loop: false, createPlay: createPlayOnce<TSoundName> }), //  prettier-ignore
+			music: createPlayer<TSoundName, PlayMusic>({ loadedAudio, loop: true, howl, createPlay: createPlayMusic<TSoundName> }), // prettier-ignore
+			loop: createPlayer<TSoundName, PlayLoop>({ loadedAudio, loop: true, howl, createPlay: createPlayLoop<TSoundName> }), // prettier-ignore
+			once: createPlayer<TSoundName, PlayOnce>({ loadedAudio, loop: false, howl, createPlay: createPlayOnce<TSoundName> }), //  prettier-ignore
 		};
 
 		// audioContextState and visibilityState


### PR DESCRIPTION
## Fix: Prevent crashes on low-end devices by optimizing audio loading

### Problem
Game crashes on low-end devices. 

### Reason
- Multiple Howler instances are created for the same audio file
- Each instance loads the audio file independently into memory
- Low-end devices cannot handle the excessive memory usage

### Solution
createSound -> create new Howler with loadedAudio


