### PR TITLE
fix(utils-sound): muted SFX emit a full-volume click — apply player volume to the Howl default

### DIFF
--- a/packages/utils-sound/src/createPlayer.svelte.ts
+++ b/packages/utils-sound/src/createPlayer.svelte.ts
@@ -82,8 +82,11 @@ function createPlayer<TSoundName extends string, TPlay extends Function>(playerO
 	const volume = (volume: number) => {
 		playerVolume = volume;
 
-		//Adjust the whole player volume
-		// howl.volume(playerVolume);
+		// Also set the Howl's default volume, so a sound played AFTER this runs
+		// inherits the current (e.g. muted) level. Otherwise it starts at the
+		// Howl default and emits a full-volume attack transient before
+		// initSoundVolume applies its per-sound volume — an audible click when muted.
+		playerOptions.howl.volume(playerVolume);
 
 		//adjust volume per sound
 		(Object.values(soundMap) as Sound[]).forEach((sound) => {


### PR DESCRIPTION
## What

`createPlayer.volume()` retunes sounds already in `soundMap` but never sets the Howl's own (default) volume. A sound played *after* `volume()` runs isn't in `soundMap` yet, so it starts at the Howl default (`new Howl({ volume: 1 })`) for the instant between `howl.play()` and `initSoundVolume()` applying its per-sound volume. That instant is a full-volume attack transient — audible as a **click**, most obviously when the player is muted (player volume 0), where it's the only audible part of every SFX.

## Repro

Mute (player volume → 0), then trigger one-shot SFX (e.g. a spin's reel-stop / symbol-landing sounds). Each emits a click.

## Fix

Set the Howl's default volume in `volume()` so newly-played sounds inherit the current level. The line was already present but **commented out — and as written it references `howl`, which isn't in scope** in `createPlayer` (every call site uses `playerOptions.howl`), so it could never have been re-enabled as-is — likely commented out before a refactor renamed `howl` → `playerOptions.howl`. The per-sound loop still refines each active sound; this only changes the default that new sounds start from. No change to the unmuted mix (the default was already 1).
