### PR TITLE
fix(cluster): dedupe win/explode positions — bonus freeze when a wild is in multiple clusters

### DIFF
--- a/apps/cluster/src/components/Board.svelte
+++ b/apps/cluster/src/components/Board.svelte
@@ -30,8 +30,22 @@
 		boardShow: () => (show = true),
 		boardHide: () => (show = false),
 		boardWithAnimateSymbols: async ({ symbolPositions }) => {
+			// Dedupe positions before awaiting. A board cell can appear in more
+			// than one win — a wild substitutes into multiple adjacent clusters,
+			// so each lists its position. Without dedupe, the duplicate iteration
+			// overwrites the prior `reelSymbol.oncomplete`, so the symbol's single
+			// `complete` resolves only the last await; the earlier one never
+			// settles and `Promise.all` hangs forever — the bonus/free-spin freeze
+			// (#14).
+			const seen = new Set<string>();
+			const uniquePositions = symbolPositions.filter((position) => {
+				const key = `${position.reel},${position.row}`;
+				if (seen.has(key)) return false;
+				seen.add(key);
+				return true;
+			});
 			const getPromises = () =>
-				symbolPositions.map(async (position) => {
+				uniquePositions.map(async (position) => {
 					const reelSymbol = context.stateGame.board[position.reel].reelState.symbols[position.row];
 					reelSymbol.symbolState = 'win';
 					await waitForResolve((resolve) => (reelSymbol.oncomplete = resolve));

--- a/apps/cluster/src/components/TumbleBoard.svelte
+++ b/apps/cluster/src/components/TumbleBoard.svelte
@@ -82,8 +82,19 @@
 			context.stateGame.tumbleBoardBase = [];
 		},
 		tumbleBoardExplode: async ({ explodingPositions }) => {
+			// Dedupe positions (same reason as boardWithAnimateSymbols in
+			// Board.svelte): a shared wild can appear in explodingPositions more
+			// than once; the duplicate overwrites `tumbleSymbol.oncomplete`, so the
+			// earlier await never settles and `Promise.all` hangs forever (#14).
+			const seen = new Set<string>();
+			const uniquePositions = explodingPositions.filter((position) => {
+				const key = `${position.reel},${position.row}`;
+				if (seen.has(key)) return false;
+				seen.add(key);
+				return true;
+			});
 			const getPromises = () =>
-				explodingPositions.map(async (position) => {
+				uniquePositions.map(async (position) => {
 					const tumbleSymbol = context.stateGame.tumbleBoardBase[position.reel][position.row];
 					tumbleSymbol.symbolState = 'explosion';
 					await waitForResolve((resolve) => (tumbleSymbol.oncomplete = resolve));


### PR DESCRIPTION
Addresses **#14** ("game sticks when bonus purchase") — a concrete, reproducible cause of the bonus / free-spin freeze.

## Cause

A board cell can legitimately belong to more than one win: a wild substitutes into multiple adjacent clusters, so the cluster math lists that cell in each win's `positions`. After `_.flatten(wins.map(w => w.positions))` the cell appears more than once.

`Board.svelte › boardWithAnimateSymbols` and `TumbleBoard.svelte › tumbleBoardExplode` store each position's resolver on the symbol:

```js
await waitForResolve((resolve) => (reelSymbol.oncomplete = resolve));
```

`oncomplete` is a **single slot**. A duplicate position overwrites the first resolver, so the symbol's one `complete` resolves only the last await — the earlier duplicate's promise never settles, `Promise.all` never resolves, and the round hangs forever.

It only triggers when an event contains a repeated cell (a wild bridging two clusters), which is why it surfaces in bonus and not base, and why the committed Storybook fixtures (`bonus_books.ts` — 50 books / 308 `winInfo` events) don't surface it: none of them happen to contain an overlap. Such events do occur in normal `0_0_cluster` sims.

## Repro

A `winInfo` (or tumble) event whose wins share a cell (illustrative shape):

```js
wins: [
  { positions: [{ reel: 0, row: 2 }, { reel: 0, row: 3 }] }, // cluster A, incl. wild (0,2)
  { positions: [{ reel: 0, row: 2 }, { reel: 1, row: 2 }] }, // cluster B, same wild (0,2)
]
```

`(0,2)` is awaited twice → the round never returns to idle.

## Fix

Dedupe positions by `(reel,row)` before building the promise array, in both handlers. A cell is one symbol with one `oncomplete`; awaiting it once is correct and the visuals are unchanged.
